### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Send me a pull request and make sure tests pass on [travis](https://travis-ci.or
 
 ## Tests
 
-Package comes with an extensive test suite that's continously run on travis against go versions: 1.3, 1.4 and the development tip.
+Package comes with an extensive test suite that's continuously run on travis against go versions: 1.3, 1.4 and the development tip.
 ```
 $ go test github.com/tomazk/envcfg
 ```


### PR DESCRIPTION
@tomazk, I've corrected a typographical error in the documentation of the [envcfg](https://github.com/tomazk/envcfg) project. Specifically, I've changed continous to continuous. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
