### PR TITLE
add support for fields that satisfy encoding.TextUnmarshaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ envcfg.Unmarshal(&val1) // val1 will be initialized
 
 #### Supported Struct Field Types 
 
-`envcfg.Unmarshal` supports `int`, `string`, `bool` and `[]int`, `[]string`, `[]bool` types of fields wihin a struct. It will return nil if a valid struct was passed or return an error if not.
+`envcfg.Unmarshal` supports `int`, `string`, `bool` and `[]int`, `[]string`, `[]bool` types of fields wihin a struct. In addition, fields that satisfy the `encoding.TextUnmarshaler` interface are also supported. `envcfg.Unmarshal` will return nil if a valid struct was passed or return an error if not.
+
 ```go
 type StructType struct {
 	INT           int
@@ -74,6 +75,12 @@ type StructType struct {
 	SLICE_STRING  []string
 	SLICE_BOOL    []bool
 	SLICE_INT     []int
+	CUSTOM_TYPE   MyType
+}
+
+type MyType struct{}
+func (mt *MyType) UnmarshalText(text []byte) error {
+	...
 }
 ```
 #### Validation

--- a/envcfg_test.go
+++ b/envcfg_test.go
@@ -67,6 +67,20 @@ type cfgValid2 struct {
 	INT       validType
 }
 
+type validTextUnmarshaler struct {
+	FLOAT float64
+}
+
+func (s *validTextUnmarshaler) UnmarshalText(text []byte) error {
+	s.FLOAT = 1.0
+	return nil
+}
+
+type cfgValid3 struct {
+	TEXT_UNMARSHALER     validTextUnmarshaler
+	TEXT_UNMARSHALER_PTR *validTextUnmarshaler
+}
+
 type cfgInvalid1 struct {
 	FLOAT float64
 }
@@ -101,6 +115,12 @@ func TestUnmarshalValidateType(t *testing.T) {
 	var v1 cfgValid2
 	if err := Unmarshal(&v1); err != nil {
 		t.Fatal("should not fail since we passed another valid value")
+	}
+
+	var v2 cfgValid3
+	if err := Unmarshal(&v2); err != nil {
+		// t.Fatal("should not fail since we passed another valid value")
+		t.Fatal(err)
 	}
 
 	var inv1 cfgInvalid1

--- a/envcfg_test.go
+++ b/envcfg_test.go
@@ -68,11 +68,11 @@ type cfgValid2 struct {
 }
 
 type validTextUnmarshaler struct {
-	DummyFloat float64
+	MyText string
 }
 
 func (s *validTextUnmarshaler) UnmarshalText(text []byte) error {
-	s.DummyFloat = 1.0
+	s.MyText = "my" + string(text)
 	return nil
 }
 
@@ -283,7 +283,7 @@ func TestUnmarshalTextUnmarshaler(t *testing.T) {
 	setEnv(t, "TEXT_UNMARSHALER", "abc")
 	var v TextUnmarshalerType
 	Unmarshal(&v)
-	if v.TEXT_UNMARSHALER.DummyFloat != 1.0 {
+	if v.TEXT_UNMARSHALER.MyText != "myabc" {
 		t.Fatal("unmarshalled value should be correct")
 	}
 }
@@ -308,7 +308,7 @@ func TestUnmarshalSlice(t *testing.T) {
 
 	var s SliceType
 	Unmarshal(&s)
-	if !reflect.DeepEqual(s, SliceType{[]string{"foo", "bar"}, []int{1, 2}, []bool{true, false}, []validTextUnmarshaler{{1.0}, {1.0}}}) {
+	if !reflect.DeepEqual(s, SliceType{[]string{"foo", "bar"}, []int{1, 2}, []bool{true, false}, []validTextUnmarshaler{{"myabc"}, {"mycde"}}}) {
 		t.Log(s)
 		t.Fatal("should be equal")
 	}


### PR DESCRIPTION
This adds support for fields that satisfy TextUnmarshaler interface. This allows defining custom data structures, example here https://github.com/BurntSushi/toml#using-the-encodingtextunmarshaler-interface
